### PR TITLE
Flatten pool right after creation; remove cluster ID parameter

### DIFF
--- a/linode/lkenodepool/framework_models.go
+++ b/linode/lkenodepool/framework_models.go
@@ -70,9 +70,10 @@ func flattenLKENodePoolLinodeList(nodes []linodego.LKENodePoolLinode,
 	return &result, nil
 }
 
-func (pool *NodePoolModel) FlattenLKENodePool(clusterID int, p *linodego.LKENodePool, preserveKnown bool, diags *diag.Diagnostics) {
+func (pool *NodePoolModel) FlattenLKENodePool(
+	p *linodego.LKENodePool, preserveKnown bool, diags *diag.Diagnostics,
+) {
 	pool.ID = helper.KeepOrUpdateString(pool.ID, strconv.Itoa(p.ID), preserveKnown)
-	pool.ClusterID = helper.KeepOrUpdateInt64(pool.ClusterID, int64(clusterID), preserveKnown)
 	pool.Count = helper.KeepOrUpdateInt64(pool.Count, int64(p.Count), preserveKnown)
 	pool.Type = helper.KeepOrUpdateString(pool.Type, p.Type, preserveKnown)
 	pool.Tags = helper.KeepOrUpdateStringSet(pool.Tags, p.Tags, preserveKnown, diags)

--- a/linode/lkenodepool/framework_models_unit_test.go
+++ b/linode/lkenodepool/framework_models_unit_test.go
@@ -33,15 +33,13 @@ func TestParseNodePool(t *testing.T) {
 		},
 	}
 
-	clusterID := 1
 	nodePoolModel := NodePoolModel{}
 	var diags diag.Diagnostics
 
-	nodePoolModel.FlattenLKENodePool(clusterID, &lkeNodePool, false, &diags)
+	nodePoolModel.FlattenLKENodePool(&lkeNodePool, false, &diags)
 
 	assert.False(t, diags.HasError())
 	assert.Equal(t, "123", nodePoolModel.ID.ValueString())
-	assert.Equal(t, int64(1), nodePoolModel.ClusterID.ValueInt64())
 	assert.Equal(t, int64(3), nodePoolModel.Count.ValueInt64())
 	assert.Equal(t, "g6-standard-2", nodePoolModel.Type.ValueString())
 	assert.Len(t, nodePoolModel.Nodes.Elements(), 3)


### PR DESCRIPTION
## 📝 Description

- Add pool and cluster IDs right after the creation to prevent resource leaking when the waiting failed.
- Remove unnecessary `clusterID` from `FlattenLKENodePool` function because `clusterID` is a required attribute, thus must be in the state or plan prior to entering CRUD functions.